### PR TITLE
Update root cause locations for cve-2017-15232

### DIFF
--- a/targets/libjpeg_cve-2017-15232/root_causes/locations
+++ b/targets/libjpeg_cve-2017-15232/root_causes/locations
@@ -1,4 +1,8 @@
-jquant1.c:534
 jquant1.c:521
+jquant1.c:522
+jquant1.c:528
+jquant1.c:532
+jquant1.c:534
 jdpostct.c:131
+jdpostct.c:132
 jdpostct.c:135


### PR DESCRIPTION
I added a line around the patched location as ground truth.