### PR TITLE
Added linters to GitHub Actions workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,11 +43,16 @@ jobs:
         uses: actions/checkout@v3
       - name: Install shellcheck
         run: wget -O- -q $SHELLCHECK_URL | sudo tar -xJ -C /usr/local/bin --strip-components=1 --wildcards --no-same-owner --no-same-permissions '*/shellcheck'
-      - name: Run shellcheck
-        uses: liskin/gh-problem-matcher-wrap@v2
+      - uses: liskin/gh-problem-matcher-wrap@v2
         with:
+          action: add
           linters: gcc
-          run: for file in $(find . -name *.sh); do /usr/local/bin/shellcheck --format=gcc --severity=warning $file; done;
+      - name: Run shellcheck
+        run: for file in $(find . -name *.sh); do /usr/local/bin/shellcheck --format=gcc --severity=warning $file; done;
+      - uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          action: remove
+          linters: gcc
   flake8:
     name: flake8
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Run hadolint
+      - name: Lint data_augmentation Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
+          dockerfile: data_augmentation/Dockerfile
+          verbose: true
+          failure-threshold: error
+      - name: Lint feature_extraction Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: feature_extraction/Dockerfile
           verbose: true
           failure-threshold: error
   shellcheck:
@@ -43,7 +50,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Install flake8~=6.0.0
-        run: pip install flake8
+      - name: Install flake8
+        run: pip install flake8~=6.0.0
       - name: Run flake8
         run: flake8 .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+name: lint
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**Dockerfile'
+      - '**.sh'
+      - '**.py'
+  workflow_dispatch:
+
+jobs:
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          verbose: true
+          failure-threshold: error
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0
+  flake8:
+    name: flake8
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install flake8~=6.0.0
+        run: pip install flake8
+      - name: Run flake8
+        run: flake8 .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ on:
       - '**.py'
   workflow_dispatch:
 
+env:
+  SHELLCHECK_URL: https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz
+
 jobs:
   hadolint:
     name: hadolint
@@ -38,8 +41,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install shellcheck
+        run: wget -O- -q $SHELLCHECK_URL | sudo tar -xJ -C /usr/local/bin --strip-components=1 --wildcards --no-same-owner --no-same-permissions '*/shellcheck'
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: for file in $(find . -name *.sh); do /usr/local/bin/shellcheck --format=gcc --severity=warning $file; done;
   flake8:
     name: flake8
     runs-on: ubuntu-20.04
@@ -53,4 +61,7 @@ jobs:
       - name: Install flake8
         run: pip install flake8~=6.0.0
       - name: Run flake8
-        run: flake8 .
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: flake8
+          run: flake8 --exit-zero .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
           action: add
           linters: gcc
       - name: Run shellcheck
-        run: for file in $(find . -name *.sh); do /usr/local/bin/shellcheck --format=gcc --severity=warning $file; done;
+        run: for file in $(find . -name *.sh); do /usr/local/bin/shellcheck --format=gcc --severity=warning $file && :; done;
       - uses: liskin/gh-problem-matcher-wrap@v2
         with:
           action: remove

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
           action: add
           linters: gcc
       - name: Run shellcheck
-        run: for file in $(find . -name *.sh); do /usr/local/bin/shellcheck --format=gcc --severity=warning $file && :; done;
+        run: for file in $(find . -name *.sh); do /usr/local/bin/shellcheck --format=gcc --severity=warning $file && :; done; true
       - uses: liskin/gh-problem-matcher-wrap@v2
         with:
           action: remove


### PR DESCRIPTION
Added following linters to GitHub Actions workflow.
* hadolint (for Dockerfile)
* ShellCheck (for shell script)
* Flake8 (for Python script)

~I'm creating the PR as a draft at this time because I'm aware that the linter will output many problems.~
All linter jobs will succeed even if some problems are detected. This is still useful for checking annotations.
